### PR TITLE
Upgraded UETools for support of upcoming DBD 4.2.0

### DIFF
--- a/DBD-API/DBD-API.csproj
+++ b/DBD-API/DBD-API.csproj
@@ -46,11 +46,11 @@
     <PackageReference Include="SharpZipLib" Version="1.2.0" />
     <PackageReference Include="SmartFormat.NET" Version="2.5.0" />
     <PackageReference Include="SteamKit2" Version="2.2.0" />
-    <PackageReference Include="UETools.Assets" Version="0.2.3" />
-    <PackageReference Include="UETools.Core" Version="0.2.3" />
-    <PackageReference Include="UETools.Objects" Version="0.2.3" />
-    <PackageReference Include="UETools.Pak" Version="0.2.3" />
-    <PackageReference Include="UETools.TypeFactory" Version="0.2.3" />
+    <PackageReference Include="UETools.Assets" Version="0.3.1" />
+    <PackageReference Include="UETools.Core" Version="0.3.1" />
+    <PackageReference Include="UETools.Objects" Version="0.3.1" />
+    <PackageReference Include="UETools.Pak" Version="0.3.1" />
+    <PackageReference Include="UETools.TypeFactory" Version="0.3.1" />
     <PackageReference Include="zlib.net" Version="1.0.4" />
   </ItemGroup>
 

--- a/DBD-API/Services/SteamDepotService.cs
+++ b/DBD-API/Services/SteamDepotService.cs
@@ -77,7 +77,7 @@ namespace DBD_API.Services
 
             await using var data = await localizationTable.Value.ReadAsync();
             data.Version = UE4Version.VER_UE4_AUTOMATIC_VERSION;
-            LocResAsset.English.Deserialize(data);
+            LocResAsset.English.Serialize(data);
             return LocResAsset.English;
 
         }
@@ -93,12 +93,13 @@ namespace DBD_API.Services
                 {
                     data.Version = UE4Version.VER_UE4_AUTOMATIC_VERSION;
                     data.Localization = localization;
-                    data.Read(out UAssetAsset asset);
+                    UAssetAsset asset = null;
+                    data.Read(ref asset);
 
-                    var dataTable = asset.GetAssets()
-                        .FirstOrDefault(x => x.FullName == $"DataTable {typeName}");
+                    var dataTable = asset.GetExportsOfType<DataTable>()
+                        .FirstOrDefault();
 
-                    if (dataTable == null || !(dataTable.Object is UETools.Objects.Classes.DataTable items))
+                    if (!(dataTable is DataTable items))
                         continue;
 
                     foreach (var (itemName, itemInfo) in items.Rows)
@@ -175,7 +176,7 @@ namespace DBD_API.Services
                 _dbdService.CustomItemInfos[branch] = itemInfos;
             }
 
-            await LoadDBFromPak(pakReader, localization, itemInfos, "ItemDB", "CustomizationItemDB");
+            await LoadDBFromPak(pakReader, localization, itemInfos, "CustomizationItemDB");
         }
 
         private async Task ReadTunableInfo(PakVFS pakReader, LocalizationTable localization, string branch, string name, string tunable,
@@ -193,12 +194,13 @@ namespace DBD_API.Services
             {
                 data.Version = UE4Version.VER_UE4_AUTOMATIC_VERSION;
                 data.Localization = localization;
-                data.Read(out UAssetAsset asset);
+                UAssetAsset asset = null;
+                data.Read(ref asset);
 
-                var dataTable = asset.GetAssets()
-                    .FirstOrDefault(x => x.FullName.StartsWith("DataTable"));
+                var dataTable = asset.GetExportsOfType<DataTable>()
+                    .FirstOrDefault();
 
-                if (dataTable == null || !(dataTable.Object is DataTable items))
+                if (!(dataTable is DataTable items))
                     return;
 
                 tunableInfos[name] = new TunableInfo(items.Rows);


### PR DESCRIPTION
Added support for UE4 4.25, used by upcoming DBD release.
Didn't see any differences in read data after change of CustomizationItemDB retrieval.